### PR TITLE
Amend schema to allow collab to have affiliations

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -587,6 +587,10 @@
             "collab": {
               "type": "string"
             },
+            "affiliations": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/affiliation"}
+            },
             "references": {
               "type": "object",
               "properties": {


### PR DESCRIPTION
POA articles don't use affiliation contributor references and we have an article that is failing validation because a collab contributor has an affiliation:

http://s3.amazonaws.com/elife-articles-renamed/samples05/article-xml/elife-02725-v1.xml

Once this has been merged in. It should allow the elife-website tests to pass in the following PR: https://github.com/elifesciences/elife-website/pull/158
