### PR TITLE
Relax elocation-id to allow for testing ids

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -26,7 +26,7 @@
     },
     "elocation-id": {
       "type": "string",
-      "pattern": "^e[0-9]{5}$"
+      "pattern": "^e[0-9]{5,}$"
     },
     "article-id": {
       "type": "string"


### PR DESCRIPTION
In testing I am trying to use autogenerated very large article ids, like `20160530120000`, so that tests do not conflict from each other and it is always possible to get a new id for running a test again and again over new versions of the code.

However, the schema limits the id space to `00000` to `99999`, which is very few. Incidentally, this change will also make it immediately clear that an id has been generated for testing. No testing id gets to the live environment, as they are only used in the `end2end` one.